### PR TITLE
Fix urlEncode cast

### DIFF
--- a/espChat.ino
+++ b/espChat.ino
@@ -39,7 +39,7 @@ String urlEncode(const String& str) {
     if (isalnum(c)) {
       encoded += c;
     } else {
-      sprintf(bufHex, "%%%02X", c);
+      sprintf(bufHex, "%%%02X", (unsigned char)c);
       encoded += bufHex;
     }
   }


### PR DESCRIPTION
## Summary
- fix the `urlEncode` helper to print chars as unsigned values

## Testing
- `g++ test_url_encode.cpp -o test_url_encode`
- `./test_url_encode`


------
https://chatgpt.com/codex/tasks/task_e_68562ba345b48327a9d400cd8347e0d1