### PR TITLE
Handle POST response status

### DIFF
--- a/espChat.ino
+++ b/espChat.ino
@@ -260,12 +260,13 @@ void sendMessage(String content) {
   String json;
   serializeJson(doc, json);
 
-
+  // POST the message and expect an HTTP 201 Created response
   int code = https.POST(json);
-  if (code > 0) {
+  String resp = https.getString();
+  if (code == 201 || code == 200) {
     Serial.println("📤 Sent");
   } else {
-    Serial.printf("❌ Send failed: %s\n", https.errorToString(code).c_str());
+    Serial.printf("❌ Send failed (%d): %s\n", code, resp.c_str());
   }
   https.end();
 }


### PR DESCRIPTION
## Summary
- check POST status codes when sending messages
- log the response body for failures

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68562baed46483279a19813da1e25bc3