### PR TITLE
Improve JSON memory usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,15 @@
 # esp-chat
 A esp32 project for chat on airgapped PCs
+
+## Memory considerations
+
+When fetching messages, the sketch previously allocated a fixed 8 KB
+`DynamicJsonDocument`.  Actual payload sizes depend on the number of
+messages and their content.  The code now estimates required capacity
+using ArduinoJson's `JSON_ARRAY_SIZE`/`JSON_OBJECT_SIZE` macros with an
+average message length of ~200 characters.  This reduces waste while
+allowing larger payloads.
+
+For very large responses, consider parsing the HTTP stream directly as
+shown in `fetchMessages()` to avoid building a large intermediate
+string.

--- a/espChat.ino
+++ b/espChat.ino
@@ -251,7 +251,10 @@ void sendMessage(String content) {
   https.addHeader("apikey", supabaseKey);
   https.addHeader("Authorization", "Bearer " + String(supabaseKey));
 
-  DynamicJsonDocument doc(512);
+  size_t cap = JSON_OBJECT_SIZE(4) +
+                content.length() + userName.length() +
+                userId.length() + avatarColor.length() + 64;
+  DynamicJsonDocument doc(cap);
   doc["content"] = content;
   doc["user_name"] = userName;
   doc["user_id"] = userId;
@@ -285,10 +288,11 @@ void fetchMessages() {
 
   int httpCode = https.GET();
   if (httpCode == 200) {
-    String payload = https.getString();
-    DynamicJsonDocument doc(8192);
+    const size_t AVG_MSG = 200; // avg chars per message
+    size_t capacity = JSON_ARRAY_SIZE(50) + 50 * JSON_OBJECT_SIZE(4) + 50 * AVG_MSG;
+    DynamicJsonDocument doc(capacity);
 
-    DeserializationError err = deserializeJson(doc, payload);
+    DeserializationError err = deserializeJson(doc, https.getStream());
     if (err) {
       Serial.printf("❌ Fetch JSON parse error: %s\n", err.c_str());
       https.end();


### PR DESCRIPTION
## Summary
- tune `DynamicJsonDocument` sizes
- parse message payload directly from HTTP stream
- document memory considerations

## Testing
- `arduino-cli compile --fqbn esp32:esp32:esp32 --warnings none .` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68562bbb0acc83278e4ed6d2e2b60f87