### PR TITLE
Add Supabase firmware migration

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,15 +45,35 @@ Type `!help` in the serial console to see available commands:
 
 ## Firmware updates
 
-The device queries a `firmware_updates` table in Supabase to check for newer firmware. Create a table with columns:
+SQL migrations for the Supabase setup live in `supabase/migrations`.  They create
+the `firmware_updates` table and grant anonymous read access.  To configure a new
+project manually, follow these steps:
 
-| Column | Type | Description |
-|-------|------|-------------|
-| `version` | text | firmware version string |
-| `binary_url` | text | HTTPS URL to the compiled `.bin` file |
+1. **Create a Storage bucket** named `firmware` and enable public access.  Upload
+   compiled `.bin` files here.
+2. **Create the tracking table** by running the migration or executing:
 
-Upload the new binary and insert a row with its version and URL. The sketch fetches
-`https://<project>.supabase.co/rest/v1/firmware_updates?select=version,binary_url&order=version.desc&limit=1` and if the version differs from `CURRENT_VERSION` it downloads and installs the update.
+   ```sql
+   create table firmware_updates (
+     id bigserial primary key,
+     version text not null,
+     binary_url text not null,
+     created_at timestamp with time zone default now()
+   );
+   alter table firmware_updates enable row level security;
+   create policy "Allow public read" on firmware_updates for select using (true);
+   ```
+3. **Insert an initial firmware row** pointing to your uploaded binary:
+
+   ```sql
+   insert into firmware_updates (version, binary_url)
+   values ('1.1.0',
+     'https://<project>.supabase.co/storage/v1/object/public/firmware/chatbox-v1.1.0.bin');
+   ```
+
+Devices fetch
+`https://<project>.supabase.co/rest/v1/firmware_updates?select=version,binary_url&order=version.desc&limit=1`
+and apply an update when the returned version differs from `CURRENT_VERSION`.
 
 ## License
 

--- a/supabase/migrations/202406220001_create_firmware.sql
+++ b/supabase/migrations/202406220001_create_firmware.sql
@@ -1,0 +1,25 @@
+-- Migration: create firmware bucket and firmware_updates table
+begin;
+
+-- Create public bucket for OTA binaries
+select storage.create_bucket('firmware', public := true);
+
+-- Table to track available firmware
+create table firmware_updates (
+  id bigserial primary key,
+  version text not null,
+  binary_url text not null,
+  created_at timestamp with time zone default now()
+);
+
+-- Allow ESP devices to read the latest firmware
+alter table firmware_updates enable row level security;
+create policy "Allow public read" on firmware_updates
+  for select using (true);
+
+-- Insert initial firmware row
+insert into firmware_updates (version, binary_url)
+values ('1.1.0',
+  'https://qymcapixzxuvzcgdjksq.supabase.co/storage/v1/object/public/firmware/chatbox-v1.1.0.bin');
+
+commit;


### PR DESCRIPTION
## Summary
- add SQL migration for firmware bucket and tracking table
- document OTA setup steps in README

## Testing
- `true`

------
https://chatgpt.com/codex/tasks/task_e_68588cc2a3748327a402c2a6c43f7888